### PR TITLE
Make the google sign in text black

### DIFF
--- a/lib/button_view.dart
+++ b/lib/button_view.dart
@@ -62,7 +62,7 @@ class SignInButton extends StatelessWidget {
           key: const ValueKey('Google'),
           text: text ?? 'Sign in with Google',
           textColor: button == Buttons.Google
-              ? const Color.fromRGBO(0, 0, 0, 0.54)
+              ? const Color(0xFF000000)
               : const Color(0xFFFFFFFF),
           image: Container(
             margin: const EdgeInsets.fromLTRB(0.0, 0.0, 10.0, 0.0),


### PR DESCRIPTION
The grey sign in text for google sign in makes the button look disabled suggesting to users that google sign in is not available. Make it black instead.